### PR TITLE
SelectelStorage::error

### DIFF
--- a/SelectelStorage.php
+++ b/SelectelStorage.php
@@ -76,7 +76,7 @@ class SelectelStorage
 	 *
 	 * @return integer
 	 */
-	private function error($code, $message)
+	protected function error($code, $message)
 	{
 		if (self::$throwExcaptions) throw new SelectelStorageException($message, $code);
 		return $code;


### PR DESCRIPTION
SelectelStorage::error используется в SelectelContainer и должна быть protected. 
