### PR TITLE
Set CURLOPT_SSL_VERIFYHOST to production value

### DIFF
--- a/SelectelStorage.php
+++ b/SelectelStorage.php
@@ -471,7 +471,7 @@ class sCurl
 		curl_setopt($this->ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($this->ch, CURLOPT_HEADER, true);
 		curl_setopt($this->ch, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, true);
+		curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, 2);
 		curl_setopt($this->ch, CURLOPT_BINARYTRANSFER, true);		
 // TODO: big files
 // curl_setopt($this->ch, CURLOPT_RANGE, "0-100");


### PR DESCRIPTION
http://www.php.net/manual/en/function.curl-setopt.php
CURLOPT_SSL_VERIFYHOST:  1 to check the existence of a common name in the SSL peer certificate. 2 to check the existence of a common name and also verify that it matches the hostname provided. In production environments the value of this option should be kept at 2 (default value).

CURLOPT_SSL_VERIFYHOST:  Используйте 1 для проверки существования общего имени в сертификате SSL. Используйте 2 для проверки существования общего имени и также его совпадения с указанным хостом. В боевом окружении значение этого параметра должно быть 2 (установлено по умолчанию).
