### PR TITLE
upd getX()

### DIFF
--- a/src/SelectelStorage.php
+++ b/src/SelectelStorage.php
@@ -102,7 +102,7 @@ class SelectelStorage
     {
         $result = array();
         foreach($headers as $key => $value)
-            if (stripos($key, "x-") === 0)
+            if (stripos($key, $prefix) === 0)
                 $result[$key] = $value;
         return $result;
     }


### PR DESCRIPTION
Аргумент $prefix не использовался в функции.
Не критично - getX($headers, "X-Container-Meta-"); возвращал все X-* вместо X-Container-Meta-*