### PR TITLE
fix-deprecated-curlopt-binarytransfer

### DIFF
--- a/src/SCurl.php
+++ b/src/SCurl.php
@@ -64,7 +64,10 @@ class SCurl
         curl_setopt($this->ch, CURLOPT_HEADER, true);
         curl_setopt($this->ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, 2);
-        curl_setopt($this->ch, CURLOPT_BINARYTRANSFER, true);
+        // Проверяем существование константы перед использованием для совместимости c php 8.4
+        if (defined('CURLOPT_BINARYTRANSFER')) {
+            curl_setopt($this->ch, CURLOPT_BINARYTRANSFER, true);
+        }
 // TODO: big files
 // curl_setopt($this->ch, CURLOPT_RANGE, "0-100");
     }


### PR DESCRIPTION
Добавлена обратная совместимость для CURLOPT_BINARYTRANSFER

- Добавлена проверка наличия константы CURLOPT_BINARYTRANSFER
- Устранено предупреждение о deprecated константе в новых версиях PHP
- Сохранена поддержка старых версий PHP